### PR TITLE
fix missing margin definitions for smartphone

### DIFF
--- a/src/Resources/public/css/columns.css
+++ b/src/Resources/public/css/columns.css
@@ -171,7 +171,14 @@
 }
 @media screen and (max-width: 599px) {
   .rs-column {
+    margin-top: 7.69231%;
     margin-right: 7.69231%;
+  }
+  .rs-column.-large-last {
+    margin-right: 7.69231%;
+  }
+  .rs-column.-large-first-row {
+    margin-top: 7.69231%;
   }
   .rs-column.-medium-first {
     clear: none;

--- a/src/Resources/public/sass/columns.sass
+++ b/src/Resources/public/sass/columns.sass
@@ -46,7 +46,12 @@
 	// Mobile (viewport width 599px and below)
 	@media screen and (max-width: 599px)
 		$gutter-width: (1 / 13)
+		margin-top: ($gutter-width * 100%)
 		margin-right: ($gutter-width * 100%)
+		&.-large-last
+			margin-right: ($gutter-width * 100%)
+		&.-large-first-row
+			margin-top: ($gutter-width * 100%)
 		&.-medium-first
 			clear: none
 		&.-medium-last


### PR DESCRIPTION
In case the `$gutter-width` is defined different by the user for the smartphone breakpoint, the margin reset is missing for the `-large-` classes. This means that some columns would have the margins from the desktop view on the smartphone view.